### PR TITLE
fix: scroll behavior if menu has multiple scrollable ancestors

### DIFF
--- a/src/text-input-autocomplete-menu.component.ts
+++ b/src/text-input-autocomplete-menu.component.ts
@@ -82,14 +82,17 @@ export class TextInputAutocompleteMenuComponent {
 
   private scrollToChoice(index: number) {
     this.activeChoice = this._choices[index];
+    
     if (this.dropdownMenuElement) {
       const ulPosition = this.dropdownMenuElement.nativeElement.getBoundingClientRect();
       const li = this.dropdownMenuElement.nativeElement.children[index];
       const liPosition = li.getBoundingClientRect();
-      if (liPosition.top < ulPosition.top) {
-        li.scrollIntoView();
-      } else if (liPosition.bottom > ulPosition.bottom) {
-        li.scrollIntoView(false);
+      
+      if (liPosition.top < ulPosition.top || liPosition.bottom > ulPosition.bottom) {
+        li.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest'
+        });
       }
     }
   }


### PR DESCRIPTION
…ancestors.

When moving the selection down to the last visble item or up to the first one and the container of the input is scrollable, the autocomplete popup menu scrolls all scrollable ancestors, not only the the nearest one.