### PR TITLE
Bootstrap dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ export class DemoComponent {
   }
 }
 ```
+Npm install bootstrap packahe or, alternatively, in the index.html file, add bootstrap dependencies with the link tag in the head section and the script tag in the body section.
+```
+<!doctype html>
+<html lang="en">
+<head>
+  (...)
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+</head>
+<body class="mat-typography">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>
+  <app-root></app-root>
+</body>
+</html>
+```
+
 
 You may also find it useful to view the [demo source](https://github.com/mattlewis92/angular-text-input-autocomplete/blob/master/demo/demo.component.ts).
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export class DemoComponent {
   }
 }
 ```
-Npm install bootstrap packahe or, alternatively, in the index.html file, add bootstrap dependencies with the link tag in the head section and the script tag in the body section.
+Npm install bootstrap package or, alternatively, in the index.html file, add bootstrap dependencies with the link tag in the head section and the script tag in the body section.
 ```
 <!doctype html>
 <html lang="en">


### PR DESCRIPTION
First, thank you so much for sharing this and many other respositories.
Second, sorry if a messed up something here with github, because this is my first pull rest. 
I would rather ask first for advice, but I was unable to contact you in other way.

In my angular project, I was able to use this directive and component module only after installing bootstrap.
Is it really necessary to install bootstrap afther installing this module?
Do you guys have the same funcionality, based on material menu component?

Many thanks!